### PR TITLE
Cleanup on destroy

### DIFF
--- a/cogs/groupsCog.py
+++ b/cogs/groupsCog.py
@@ -51,17 +51,23 @@ class GroupCommands(commands.Cog):
     async def gdestroy(self, ctx, group_prefix: str = commands.parameter(description="Your group (short name)")):
         group_name = f"{group_prefix}_{ctx.author}"
         status, result_str = organize_group.destroy_group(group_name)
-
         # if status, delete channels and role
+        status=True
         if status:
-            # create category
-            category = await ctx.guild.create_category(name=group_name)
+            # remove role
+            role = discord.utils.get(ctx.guild.roles, name=group_name)
+            if role:
+                await role.delete()
+
+            # remove category
+            category = discord.utils.get(ctx.guild.categories, name=group_name)
+            if category:
+                await category.delete()
             # remove channels
-            existing_channel = discord.utils.get(ctx.guild.channels, name=group_name)
-            print(existing_channel)
-            # if the channel exists
-            #if existing_channel is not None:
-            #    await existing_channel.delete()
+            for channel in ctx.guild.channels:
+                if str(channel) == group_name or str(channel) == group_name.replace("#", "").lower():
+                    print("Deleting", channel)
+                    await channel.delete()
 
         await ctx.send(result_str)
 

--- a/cogs/groupsCog.py
+++ b/cogs/groupsCog.py
@@ -56,9 +56,12 @@ class GroupCommands(commands.Cog):
         if status:
             # create category
             category = await ctx.guild.create_category(name=group_name)
-            # create channels
-            await ctx.guild.create_text_channel(name=group_name, overwrites=overwrites, category=category)
-            await ctx.guild.create_voice_channel(name=group_name, overwrites=overwrites, category=category)
+            # remove channels
+            existing_channel = discord.utils.get(ctx.guild.channels, name=group_name)
+            print(existing_channel)
+            # if the channel exists
+            #if existing_channel is not None:
+            #    await existing_channel.delete()
 
         await ctx.send(result_str)
 

--- a/cogs/groupsCog.py
+++ b/cogs/groupsCog.py
@@ -51,7 +51,15 @@ class GroupCommands(commands.Cog):
     async def gdestroy(self, ctx, group_prefix: str = commands.parameter(description="Your group (short name)")):
         group_name = f"{group_prefix}_{ctx.author}"
         status, result_str = organize_group.destroy_group(group_name)
-        # if exit_status, delete channels and role
+
+        # if status, delete channels and role
+        if status:
+            # create category
+            category = await ctx.guild.create_category(name=group_name)
+            # create channels
+            await ctx.guild.create_text_channel(name=group_name, overwrites=overwrites, category=category)
+            await ctx.guild.create_voice_channel(name=group_name, overwrites=overwrites, category=category)
+
         await ctx.send(result_str)
 
     @commands.command(

--- a/cogs/groupsCog.py
+++ b/cogs/groupsCog.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import discord
+import logging
 from discord.ext import commands
 from discord.utils import get
 from cogs.group import organize_group
@@ -58,16 +59,18 @@ class GroupCommands(commands.Cog):
             role = discord.utils.get(ctx.guild.roles, name=group_name)
             if role:
                 await role.delete()
+                logging.debug(f"Deleted role {role}.")
 
             # remove category
             category = discord.utils.get(ctx.guild.categories, name=group_name)
             if category:
                 await category.delete()
+                logging.debug(f"Deleted category {category}.")
             # remove channels
             for channel in ctx.guild.channels:
                 if str(channel) == group_name or str(channel) == group_name.replace("#", "").lower():
-                    print("Deleting", channel)
                     await channel.delete()
+                    logging.debug(f"Deleted channel {channel}.")
 
         await ctx.send(result_str)
 


### PR DESCRIPTION
In the past roles, categories and channels remained after group deletion. This is now fixed. This closes #8 